### PR TITLE
Martijn Bastiaan's improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ LDAP_SEARCH_BASE = 'OU=DevTeam,DC=example,DC=net'
 LDAP_USERNAME_ATTRIBUTE = 'uid'
 LDAP_EMAIL_ATTRIBUTE = 'mail'
 LDAP_FULL_NAME_ATTRIBUTE = 'displayName'
+
+# Fallback on normal authentication method if this LDAP auth fails. Uncomment to enable.
+# LDAP_FALLBACK = "normal"
 ```
 
 A dedicated domain service account user (specified by `LDAP_BIND_DN`)

--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from ldap3 import Server, Connection, SIMPLE, ANONYMOUS, SYNC, SIMPLE, SYNC, ASYNC, SUBTREE, NONE
+from ldap3 import Server, Connection, ANONYMOUS, SIMPLE, SYNC, SUBTREE, NONE
 
 from django.conf import settings
 from taiga.base.connectors.exceptions import ConnectorBaseException

--- a/tests/test_ldap.py
+++ b/tests/test_ldap.py
@@ -40,7 +40,7 @@ def test_ldap_login_success():
 
 
 def test_ldap_login_fail():
-    with pytest.raises(connector.LDAPLoginError) as e:
+    with pytest.raises(connector.LDAPError) as e:
         login = "**userName**"
         password = "**password**"
         auth_info = connector.login(login, password)


### PR DESCRIPTION
* differentiates LDAP exceptions - either Connection or UserLogin;
* allows (as a config option) to fall back to local-db auth if LDAP auth fails.

Haven't tested, but looks OK in general.