### PR TITLE
Make "slugify" a config option instead of module-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ LDAP_SEARCH_BASE = 'OU=DevTeam,DC=example,DC=net'
 LDAP_USERNAME_ATTRIBUTE = 'uid'
 LDAP_EMAIL_ATTRIBUTE = 'mail'
 LDAP_FULL_NAME_ATTRIBUTE = 'displayName'
+
+# Function to map LDAP username to local DB user unique identifier.
+# Upon successful LDAP bind, will override returned username attribute
+# value. May result in unexpected failures if changed after the database
+# has been populated.
+def _ldap_slugify(uid: str) -> str:
+    # example: force lower-case
+    #uid = uid.lower()
+    return uid
+#LDAP_MAP_USERNAME_TO_UID = _ldap_slugify
 ```
 
 A dedicated domain service account user (specified by `LDAP_BIND_DN`)

--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -17,7 +17,15 @@ from django.conf import settings
 from taiga.base.connectors.exceptions import ConnectorBaseException
 
 
-class LDAPLoginError(ConnectorBaseException):
+class LDAPError(ConnectorBaseException):
+    pass
+
+
+class LDAPConnectionError(LDAPError):
+    pass
+
+
+class LDAPUserLoginError(LDAPError):
     pass
 
 
@@ -32,6 +40,7 @@ BIND_PASSWORD = getattr(settings, "LDAP_BIND_PASSWORD", "")
 USERNAME_ATTRIBUTE = getattr(settings, "LDAP_USERNAME_ATTRIBUTE", "")
 EMAIL_ATTRIBUTE = getattr(settings, "LDAP_EMAIL_ATTRIBUTE", "")
 FULL_NAME_ATTRIBUTE = getattr(settings, "LDAP_FULL_NAME_ATTRIBUTE", "")
+
 
 def login(login: str, password: str) -> tuple:
     """
@@ -53,7 +62,7 @@ def login(login: str, password: str) -> tuple:
         server = Server(SERVER, port = PORT, get_info = NONE, use_ssl = use_ssl)
     except Exception as e:
         error = "Error connecting to LDAP server: %s" % e
-        raise LDAPLoginError({"error_message": error})
+        raise LDAPConnectionError({"error_message": error})
 
     # authenticate as service if credentials provided, anonymously otherwise
     if BIND_DN is not None and BIND_DN != '':
@@ -69,7 +78,7 @@ def login(login: str, password: str) -> tuple:
                        user = service_user, password = service_pass, authentication = service_auth)
     except Exception as e:
         error = "Error connecting to LDAP server: %s" % e
-        raise LDAPLoginError({"error_message": error})
+        raise LDAPConnectionError({"error_message": error})
 
     # search for user-provided login
     search_filter = '(|(%s=%s)(%s=%s))' % (USERNAME_ATTRIBUTE, login, EMAIL_ATTRIBUTE, login)
@@ -83,12 +92,12 @@ def login(login: str, password: str) -> tuple:
                  paged_size = 5)
     except Exception as e:
         error = "LDAP login incorrect: %s" % e
-        raise LDAPLoginError({"error_message": error})
+        raise LDAPUserLoginError({"error_message": error})
 
     # stop if no search results
     # TODO: handle multiple matches
     if len(c.response) == 0:
-        raise LDAPLoginError({"error_message": "LDAP login not found"})
+        raise LDAPUserLoginError({"error_message": "LDAP login not found"})
 
     # attempt LDAP bind
     username = c.response[0].get('raw_attributes').get(USERNAME_ATTRIBUTE)[0].decode('utf-8')
@@ -101,7 +110,7 @@ def login(login: str, password: str) -> tuple:
                                user = dn, password = password)
     except Exception as e:
         error = "LDAP bind failed: %s" % e
-        raise LDAPLoginError({"error_message": error})
+        raise LDAPUserLoginError({"error_message": error})
 
     # LDAP binding successful, but some values might have changed, or
     # this is the user's first login, so return them

--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -11,7 +11,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from ldap3 import Server, Connection, SIMPLE, ANONYMOUS, SYNC, SIMPLE, SYNC, ASYNC, SUBTREE, NONE
+from ldap3 import Server, Connection, ANONYMOUS, SIMPLE, SYNC, SUBTREE, NONE
 
 from django.conf import settings
 from taiga.base.connectors.exceptions import ConnectorBaseException

--- a/taiga_contrib_ldap_auth/services.py
+++ b/taiga_contrib_ldap_auth/services.py
@@ -12,6 +12,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from django.db import transaction as tx
+from django.conf import settings
 from django.apps import apps
 
 from taiga.base.utils.slug import slugify_uniquely
@@ -21,39 +22,7 @@ from taiga.auth.signals import user_registered as user_registered_signal
 from . import connector
 
 
-def _slugify(username: str):
-    """Deployment-specific username-to-unique-id slugification.
-
-    Taiga requires a way to map LDAP attributes to local database
-    unique identifiers. Depending on your setup, the sets of allowed
-    characters for either may overlap only partially, or one may be
-    a subset of another.
-
-    Your LDAP may allow, for example, both users `User` and `user` to
-    exist. Django's `slugify()` would map both to `user`. Taiga's
-    `slugify_uniquely()` would map either to `user` if `user` doesn't
-    yet exist in the database, and to `user-<something>` if it does -
-    possibly uniquely on each login attempt.
-
-    Edit this if your LDAP installation allows characters that Taiga
-    slugs do not allow, or if substitutions need to be performed prior
-    to slugification.
-
-    NOTE that modifying code like this is ugly at best. Then again, so
-    is making assumptions on what a username can be.
-
-    NOTE also that adding or removing constraints on an already-populated
-    database may result in unexpected failures.
-    """
-    # EXAMPLES PROVIDED BELOW MAY NOT WORK AS YOU EXPECT
-    # example: replace common symbols found in e-mail addresses
-    #username = username.replace('.', '-')
-    #username = username.replace('+', '-')
-    #username = username.replace('@', '-')
-    # example: force lower-case
-    #username = username.lower()
-
-    return username
+SLUGIFY = getattr(settings, 'LDAP_MAP_USERNAME_TO_UID', '')
 
 
 def ldap_login_func(request):
@@ -84,8 +53,10 @@ def register_or_update(username: str, email: str, full_name: str):
 
     :returns: User
     """
-    user_model = apps.get_model("users", "User")
-    username = _slugify(username)
+    user_model = apps.get_model('users', 'User')
+
+    if SLUGIFY:
+        username = SLUGIFY(username)
 
     try:
         # has user logged in before?
@@ -94,7 +65,7 @@ def register_or_update(username: str, email: str, full_name: str):
         # create a new user
         username_unique = slugify_uniquely(username,
                                            user_model,
-                                           slugfield = "username")
+                                           slugfield = 'username')
         user = user_model.objects.create(username = username_unique,
                                          email = email,
                                          full_name = full_name)

--- a/tests/test_ldap.py
+++ b/tests/test_ldap.py
@@ -36,7 +36,7 @@ def test_ldap_login_success():
 
 
 def test_ldap_login_fail():
-    with pytest.raises(connector.LDAPLoginError) as e:
+    with pytest.raises(connector.LDAPError) as e:
         login = "**userName**"
         password = "**password**"
         auth_info = connector.login(login, password)


### PR DESCRIPTION
Having `_slugify()` as a module-level function in `services` requires service operators to edit package code, which isn't pretty, and may be impossible if privilege separation (between machine sysadmin and service admin) is in place.

This moves the implementation to the config - as an option that should be set to a function. Example could have been a lambda, but I figured that if someone was to use it, it'd probably be too large to fit in one. So, providing a function "stub" instead.

This PR also includes:

* a few cherry-picked commits from @martijnbastiaan (see PR #1);
* changes strings to use single ticks/quotes instead of double ones in `services.py` - not sure if should have done it the other way around, so the entire package uses one style.